### PR TITLE
Cleanup for version 1.0

### DIFF
--- a/profile/arc_datamap_ro_crate.md
+++ b/profile/arc_datamap_ro_crate.md
@@ -102,7 +102,9 @@ It is based on [schema.org/PropertyValue](https://schema.org/PropertyValue) and 
 |@id|MUST|Text or URL||
 |value|SHOULD|Text|Explication of the data fragment contents|
 |valueReference|SHOULD|URL|Value ontology reference|
-|propertyID|SHOULD|URL|Reference to the data fragement using a [fragment selector](https://www.w3.org/TR/annotation-model/#selectors)|
+|name|MUST|Text|Must be "FragmentDescriptor"|
+|propertyID|MUST|URL|Must be ""https://github.com/nfdi4plants/ARC-specification/blob/dev/ISA-XLSX.md#datamap-table-sheets""|
+|subjectOf|SHOULD|URL|Reference to the described data fragement using a [fragment selector](https://www.w3.org/TR/annotation-model/#selectors)|
 |unitText|SHOULD|Text|Unit of the data fragment|
 |unitCode|SHOULD|URL|Unit ontology reference|
 |measurementMethod|SHOULD|Text|Name of the tool used to create the data.|

--- a/profile/arc_datamap_ro_crate.md
+++ b/profile/arc_datamap_ro_crate.md
@@ -89,6 +89,7 @@ Describes and points to a *Fragment* of a Data file. Doesn't have a corresponden
 |name|COULD|Text or URL|The name of the file.|
 |comment|COULD|[schema.org/Comment](https://schema.org/Comment)|Comment|
 |encodingFormat|COULD|Text of URL|Media format as a MIME type|
+|pattern|COULD|DefinedTerm|Defines the shape or format of entries in this fragment.|
 |disambiguatingDescription|COULD|Text|The type of the data file (“Raw Data File", “Derived Data File" or "Image File").|
 
 ### Fragment Description

--- a/profile/arc_datamap_ro_crate.md
+++ b/profile/arc_datamap_ro_crate.md
@@ -31,7 +31,7 @@ DataFragment --about--> prop
 prop -.propertyID.-> DataFragment
 
 Process --result--> DataFile
-Process --parameterValue--> prop
+Process --result--> DataFragment
 
 dataset --processSequence--> Process
 dataset --variableMeasured--> prop

--- a/profile/arc_datamap_ro_crate.md
+++ b/profile/arc_datamap_ro_crate.md
@@ -2,11 +2,11 @@
 
 ## Abstract
 
-This profile shows the inteded representation of the ARC datamap in the RO-Crate, extending the [ISA RO-Crate Profile](https://github.com/nfdi4plants/isa-ro-crate-profile). The datamap contains contextual information for fragments within data files. Data files are already referenced in their respective datasets through `hasPart` and connected to ISA processes as their output (`result`). We extend this by splitting data files into data fragments (using the same type `MediaObject` for the fragments and connecting them through `hasPart`). Furthermore, we add the contextual information per entry in the datamap to the `Dataset` objects. The fragments and their information then reference each other.
+This profile shows the intended representation of the ARC datamap in the RO-Crate, extending the [ISA RO-Crate Profile](https://github.com/nfdi4plants/isa-ro-crate-profile). The datamap contains contextual information for fragments within data files. Data files are already referenced in their respective datasets through `hasPart` and connected to ISA processes as their output (`result`). We extend this by splitting data files into data fragments (using the same type `MediaObject` for the fragments and connecting them through `hasPart`). Furthermore, we add the contextual information per entry in the datamap to the `Dataset` objects. The fragments and their information then reference each other.
 
 ## Detailed Description
 
-The current plan is to use `MediaObject` for data fragments and annotate them through the `variableMeasured` property in the assay/study `Dataset` object. Specifically, we plan the following:
+The current plan is to use `MediaObject` for data fragments and annotate them through the `variableMeasured` property in the `Dataset` object. Specifically, we plan the following:
 - Each entry in the datamap becomes one entry in `variableMeasured` of type `PropertyValue`.
 - Each data fragment becomes an object of type `MediaObject`, referenced from its file object through `hasPart`.
 - The data fragments from the data map point to descriptions in form of a `PropertyValue` through the `about` property.
@@ -15,7 +15,7 @@ The current plan is to use `MediaObject` for data fragments and annotate them th
 ```mermaid
 flowchart TD
 
-dataset[Assay/Study=Dataset]
+dataset[Dataset]
 
 Process[LabProcess]
 
@@ -33,33 +33,25 @@ prop -.subjectOf.-> DataFragment
 Process --result--> DataFile
 Process --result--> DataFragment
 
-dataset --processSequence--> Process
+dataset --about--> Process
 dataset --variableMeasured--> prop
 
 ```
 
-### Assay
+### Dataset
 
-Is based upon [schema.org/Dataset](https://schema.org/Dataset) and maps to the [ISA-JSON Assay](https://isa-specs.readthedocs.io/en/latest/isajson.html#assay-schema-json)
+Object containing and annotating data files and fragments. 
+
+In the context of ISA and specifically ARCs, these will mostly be [Assays](https://github.com/nfdi4plants/isa-ro-crate-profile/blob/release/profile/isa_ro_crate.md#assay) or [Studies](https://github.com/nfdi4plants/isa-ro-crate-profile/blob/release/profile/isa_ro_crate.md#assay) and follow the respective profiles.
 
 | Property | Required | Expected Type | Description |
 |----------|----------|---------------|-------------|
 |@type |MUST|Text|Must be '[schema.org/Dataset](https://schema.org/Dataset)'|
-|@id|MUST|Text or URL|Should be a subdirectory corresponding to this assay.|
-|additionalType|MUST|Text or URL|‘Assay’ or ontology term to identify it as an Assay|
-|creator|MUST|[schema.org/Person](https://schema.org/Person)|The performer of the experiments.|
-|identifier|MUST|Text or URL|Identifying descriptor of the assay.|
-|headline|MUST|Text|A title of the assay.|
-|about|MUST|[bioschemas.org/LabProcess](https://bioschemas.org/LabProcess)|The experimental processes performed in this assay.|
-|measurementMethod|MUST|URL or [schema.org/DefinedTerm](https://schema.org/DefinedTerm)|Describes the type measurement e.g Complexomics or transcriptomics as an ontology term|
-|measurementTechnique|MUST|URL or [schema.org/DefinedTerm](https://schema.org/DefinedTerm)|Describes the type of technology used to take the measurement, e.g mass spectrometry or deep sequencing|
-|hasPart|SHOULD|[File](https://schema.org/MediaObject)|The data files resulting from the process sequence|
-|description|SHOULD|Text|A short description of the assay (e.g. an abstract)|
-|variableMeasured|COULD|Text or [schema.org/PropertyValue](https://schema.org/PropertyValue)|Either a high level descrition of the target variable being measured (e.g. protein concentration) described as text, or a fragment description entry from the datamap as a [PropertyValue](https://schema.org/PropertyValue) followinf the fragment description profile.|
-|dateCreated|SHOULD|DateTime|When the Assay was created|
-|dateModified|SHOULD|DateTime|When the Assay was last modified|
-|citation|COULD|[schema.org/ScholarlyArticle](https://schema.org/ScholarlyArticle)|A publication corresponding to this assay.|
-|comment|COULD|[schema.org/Comment](https://schema.org/Comment)|Comment|
+|@id|MUST|Text or URL|Should be a subdirectory corresponding to this dataset.|
+|about|MUST|[bioschemas.org/LabProcess](https://bioschemas.org/LabProcess)|The experimental processes performed in this dataset. If used in ISA or ARC contect, it must follow the [LabProcess profile](https://github.com/nfdi4plants/isa-ro-crate-profile/blob/release/profile/isa_ro_crate.md#labprocess)|
+|hasPart|SHOULD|[File](https://schema.org/MediaObject)|The data files resulting from the processes performed in this dataset.|
+|variableMeasured|COULD|Text or [schema.org/PropertyValue](https://schema.org/PropertyValue)|A fragment description entry from the datamap as a [PropertyValue](https://schema.org/PropertyValue) following the [fragment description profile](#fragment-description).|
+
 
 ### Data (File)
 
@@ -73,7 +65,7 @@ Describes and points to a Data file, and maps to the [ISA-JSON Data](https://isa
 |comment|COULD|[schema.org/Comment](https://schema.org/Comment)|Comment|
 |encodingFormat|COULD|Text of URL|Media format as a MIME type|
 |disambiguatingDescription|COULD|Text|The type of the data file (“Raw Data File", “Derived Data File" or "Image File").|
-|hasPart|COULD|[File](https://schema.org/MediaObject)|The data fragments within this file. They must follow the Data Fragment profile.|
+|hasPart|COULD|[File](https://schema.org/MediaObject)|The data fragments within this file. They must follow the [Data Fragment profile](#data-fragment).|
 
 ### Data Fragment
 
@@ -84,9 +76,8 @@ Describes and points to a *Fragment* of a Data file. Doesn't have a corresponden
 |@type |MUST|Text|Must be 'File' or 'MediaObject'|
 |@id|MUST|Text or URL|Should be the path pointing to the file with a [fragment selector](https://www.w3.org/TR/annotation-model/#selectors) attached.|
 |usageInfo|MUST|Text of URL|(Formal) Description of the fragment selector.|
-|about|SHOULD|[schema.org/PropertyValue](https://schema.org/PropertyValue)|The fragment description for this fragment. It must follow the fragment description profile.|
+|about|SHOULD|[schema.org/PropertyValue](https://schema.org/PropertyValue)|The fragment description for this fragment. It must follow the [fragment description profile](#fragment-description).|
 |pattern|SHOULD|DefinedTerm|Defines the shape or format of entries in this fragment.|
-|dateCreated|SHOULD|DateTime|When the Assay was created|
 |name|COULD|Text or URL|The name of the file.|
 |comment|COULD|[schema.org/Comment](https://schema.org/Comment)|Comment|
 |encodingFormat|COULD|Text of URL|Media format as a MIME type|
@@ -94,7 +85,7 @@ Describes and points to a *Fragment* of a Data file. Doesn't have a corresponden
 
 ### Fragment Description
 
-It is based on [schema.org/PropertyValue](https://schema.org/PropertyValue) and doesn't have a corresponding ISA term.
+Adds further annotation to a *Fragment* of a Data file. Doesn't have a correspondence in ISA.
 
 | Property | Required | Expected Type | Description |
 |----------|----------|---------------|-------------|
@@ -102,7 +93,7 @@ It is based on [schema.org/PropertyValue](https://schema.org/PropertyValue) and 
 |@id|MUST|Text or URL||
 |name|MUST|Text|Must be "FragmentDescriptor"|
 |propertyID|MUST|URL|Must be "https://github.com/nfdi4plants/ARC-specification/blob/dev/ISA-XLSX.md#datamap-table-sheets"|
-|subjectOf|MUST|URL|Reference to the described data fragement using a [fragment selector](https://www.w3.org/TR/annotation-model/#selectors)|
+|subjectOf|MUST|URL|Reference to the described data fragement using a [fragment selector](https://www.w3.org/TR/annotation-model/#selectors), following the [data fragment profile](#data-fragment).|
 |value|SHOULD|Text|Explication of the data fragment contents|
 |valueReference|SHOULD|URL|Value ontology reference|
 |unitText|SHOULD|Text|Unit of the data fragment|

--- a/profile/arc_datamap_ro_crate.md
+++ b/profile/arc_datamap_ro_crate.md
@@ -107,5 +107,6 @@ It is based on [schema.org/PropertyValue](https://schema.org/PropertyValue) and 
 |valueReference|SHOULD|URL|Value ontology reference|
 |unitText|SHOULD|Text|Unit of the data fragment|
 |unitCode|SHOULD|URL|Unit ontology reference|
+|alternateName|SHOULD|Text|The label of the fragment, e.g. a column header.|
 |measurementMethod|SHOULD|Text|Name of the tool used to create the data.|
 |description|SHOULD|Text|Can be used to describe further details of the fragment|

--- a/profile/arc_datamap_ro_crate.md
+++ b/profile/arc_datamap_ro_crate.md
@@ -28,7 +28,7 @@ DataFile --hasPart--> DataFragment
 dataset --hasPart--> DataFile
 
 DataFragment --about--> prop
-prop -.propertyID.-> DataFragment
+prop -.subjectOf.-> DataFragment
 
 Process --result--> DataFile
 Process --result--> DataFragment
@@ -44,7 +44,7 @@ Is based upon [schema.org/Dataset](https://schema.org/Dataset) and maps to the [
 
 | Property | Required | Expected Type | Description |
 |----------|----------|---------------|-------------|
-|@type |MUST|Text|must be '[schema.org/Dataset](https://schema.org/Dataset)'|
+|@type |MUST|Text|Must be '[schema.org/Dataset](https://schema.org/Dataset)'|
 |@id|MUST|Text or URL|Should be a subdirectory corresponding to this assay.|
 |additionalType|MUST|Text or URL|‘Assay’ or ontology term to identify it as an Assay|
 |creator|MUST|[schema.org/Person](https://schema.org/Person)|The performer of the experiments.|
@@ -67,7 +67,7 @@ Describes and points to a Data file, and maps to the [ISA-JSON Data](https://isa
 
 | Property | Required | Expected Type | Description |
 |----------|----------|---------------|-------------|
-|@type |MUST|Text|must be 'File' or 'MediaObject'|
+|@type |MUST|Text|Must be 'File' or 'MediaObject'|
 |@id|MUST|Text or URL|Should be the path pointing to the file./
 |name|MUST|Text or URL|The name of the file.|
 |comment|COULD|[schema.org/Comment](https://schema.org/Comment)|Comment|
@@ -81,7 +81,7 @@ Describes and points to a *Fragment* of a Data file. Doesn't have a corresponden
 
 | Property | Required | Expected Type | Description |
 |----------|----------|---------------|-------------|
-|@type |MUST|Text|must be 'File' or 'MediaObject'|
+|@type |MUST|Text|Must be 'File' or 'MediaObject'|
 |@id|MUST|Text or URL|Should be the path pointing to the file with a [fragment selector](https://www.w3.org/TR/annotation-model/#selectors) attached.|
 |usageInfo|MUST|Text of URL|(Formal) Description of the fragment selector.|
 |about|SHOULD|[schema.org/PropertyValue](https://schema.org/PropertyValue)|The fragment description for this fragment. It must follow the fragment description profile.|
@@ -98,10 +98,10 @@ It is based on [schema.org/PropertyValue](https://schema.org/PropertyValue) and 
 
 | Property | Required | Expected Type | Description |
 |----------|----------|---------------|-------------|
-|@type |MUST|Text|must be '[schema.org/PropertyValue](https://schema.org/PropertyValue)'|
+|@type |MUST|Text|Must be '[schema.org/PropertyValue](https://schema.org/PropertyValue)'|
 |@id|MUST|Text or URL||
 |name|MUST|Text|Must be "FragmentDescriptor"|
-|propertyID|MUST|URL|Must be ""https://github.com/nfdi4plants/ARC-specification/blob/dev/ISA-XLSX.md#datamap-table-sheets""|
+|propertyID|MUST|URL|Must be "https://github.com/nfdi4plants/ARC-specification/blob/dev/ISA-XLSX.md#datamap-table-sheets"|
 |subjectOf|MUST|URL|Reference to the described data fragement using a [fragment selector](https://www.w3.org/TR/annotation-model/#selectors)|
 |value|SHOULD|Text|Explication of the data fragment contents|
 |valueReference|SHOULD|URL|Value ontology reference|

--- a/profile/arc_datamap_ro_crate.md
+++ b/profile/arc_datamap_ro_crate.md
@@ -85,11 +85,11 @@ Describes and points to a *Fragment* of a Data file. Doesn't have a corresponden
 |@id|MUST|Text or URL|Should be the path pointing to the file with a [fragment selector](https://www.w3.org/TR/annotation-model/#selectors) attached.|
 |usageInfo|MUST|Text of URL|(Formal) Description of the fragment selector.|
 |about|SHOULD|[schema.org/PropertyValue](https://schema.org/PropertyValue)|The fragment description for this fragment. It must follow the fragment description profile.|
+|pattern|SHOULD|DefinedTerm|Defines the shape or format of entries in this fragment.|
 |dateCreated|SHOULD|DateTime|When the Assay was created|
 |name|COULD|Text or URL|The name of the file.|
 |comment|COULD|[schema.org/Comment](https://schema.org/Comment)|Comment|
 |encodingFormat|COULD|Text of URL|Media format as a MIME type|
-|pattern|COULD|DefinedTerm|Defines the shape or format of entries in this fragment.|
 |disambiguatingDescription|COULD|Text|The type of the data file (“Raw Data File", “Derived Data File" or "Image File").|
 
 ### Fragment Description
@@ -100,11 +100,11 @@ It is based on [schema.org/PropertyValue](https://schema.org/PropertyValue) and 
 |----------|----------|---------------|-------------|
 |@type |MUST|Text|must be '[schema.org/PropertyValue](https://schema.org/PropertyValue)'|
 |@id|MUST|Text or URL||
-|value|SHOULD|Text|Explication of the data fragment contents|
-|valueReference|SHOULD|URL|Value ontology reference|
 |name|MUST|Text|Must be "FragmentDescriptor"|
 |propertyID|MUST|URL|Must be ""https://github.com/nfdi4plants/ARC-specification/blob/dev/ISA-XLSX.md#datamap-table-sheets""|
-|subjectOf|SHOULD|URL|Reference to the described data fragement using a [fragment selector](https://www.w3.org/TR/annotation-model/#selectors)|
+|subjectOf|MUST|URL|Reference to the described data fragement using a [fragment selector](https://www.w3.org/TR/annotation-model/#selectors)|
+|value|SHOULD|Text|Explication of the data fragment contents|
+|valueReference|SHOULD|URL|Value ontology reference|
 |unitText|SHOULD|Text|Unit of the data fragment|
 |unitCode|SHOULD|URL|Unit ontology reference|
 |measurementMethod|SHOULD|Text|Name of the tool used to create the data.|

--- a/profile/arc_datamap_ro_crate.md
+++ b/profile/arc_datamap_ro_crate.md
@@ -10,7 +10,7 @@ The current plan is to use `MediaObject` for data fragments and annotate them th
 - Each entry in the datamap becomes one entry in `variableMeasured` of type `PropertyValue`.
 - Each data fragment becomes an object of type `MediaObject`, referenced from its file object through `hasPart`.
 - The data fragments from the data map point to descriptions in form of a `PropertyValue` through the `about` property.
-- The `PropertyValue` objects point back through `propertyID`, although this is not a valid jsonld link.
+- The `PropertyValue` objects point back through `subjectOf`.
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
- Added `pattern` field to represent Object Type
- Removed notion of `Dataset` being restricted to represent Assay or Study
- added `alternatename` property to represent Label
- Changed `propertyID` to `subjectOf`
- Removed some unnecessary fields resulting from copying
- Various small fixes